### PR TITLE
Add postinstall script to MalwarebytesAntiMalware

### DIFF
--- a/MalwarebytesAntiMalware/MalwarebytesAntiMalware.munki.recipe
+++ b/MalwarebytesAntiMalware/MalwarebytesAntiMalware.munki.recipe
@@ -30,6 +30,34 @@
 			<string>Malwarebytes Anti-Malware</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>postinstall_script</key>
+			<string>#!/bin/sh
+
+declare -r mbam_helper="/Applications/Malwarebytes Anti-Malware.app/Contents/Library/LaunchServices/com.malwarebytes.HelperTool"
+declare -r privtools=/Library/PrivilegedHelperTools
+declare -r launchd_plist=/Library/LaunchDaemons/com.malwarebytes.HelperTool.plist
+
+# install helper tool
+if [ ! -d ${privtools} ]; then
+	/bin/mkdir -p "${privtools}"
+	/bin/chmod 1755 "${privtools}"
+fi
+/usr/bin/install -m 0544 -o root -g wheel "${mbam_helper}" ${privtools}
+
+# generate and load the LaunchDaemon if it doesn't already exist
+if [ ! -e "${launchd_plist}" ]; then
+	declare -r pb=/usr/libexec/PlistBuddy
+	${pb} -c 'Add :Label string com.malwarebytes.HelperTool' "${launchd_plist}"
+	${pb} -c 'Add :MachServices dict' "${launchd_plist}"
+	${pb} -c 'Add :MachServices:com.malwarebytes.HelperTool bool true' "${launchd_plist}"
+	${pb} -c 'Add :Program string '${privtools}'/com.malwarebytes.HelperTool' "${launchd_plist}"
+	${pb} -c 'Add :ProgramArguments array' "${launchd_plist}"
+	${pb} -c 'Add :ProgramArguments:0 string '${privtools}'/com.malwarebytes.HelperTool' "${launchd_plist}"
+	/bin/chmod 644 "${launchd_plist}"
+	/usr/sbin/chown root:wheel "${launchd_plist}"
+	/bin/launchctl load "${launchd_plist}"
+fi
+</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
This postinstall does the work that MBAM would normally prompt a user for admin rights for to set up the helper tool.