### PR TITLE
Fixed 400 error on download

### DIFF
--- a/Scratch-2/Scratch2.download.recipe
+++ b/Scratch-2/Scratch2.download.recipe
@@ -34,7 +34,7 @@
             <key>Arguments</key>
             <dict>
                <key>url</key>
-               <string>%baseurl%/scratchr2/static/sa/Scratch-%editor_version%.dmg </string>
+               <string>%baseurl%/scratchr2/static/sa/Scratch-%editor_version%.dmg</string>
                <key>filename</key>
                <string>%NAME%.dmg</string>
             </dict>


### PR DESCRIPTION
Turns out the trailing space on line 37 was messing up the request (but only sometimes...)

Fixes issue #18 