### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Burn/Burn.munki.recipe
+++ b/Burn/Burn.munki.recipe
@@ -44,7 +44,7 @@
             <key>Arguments</key>
             <dict>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.localized/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.localized/Burn.app</string>
                 <key>dmg_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
             </dict>

--- a/SQLDeveloper/SQLDeveloper.download.recipe
+++ b/SQLDeveloper/SQLDeveloper.download.recipe
@@ -64,7 +64,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/SQLDeveloper.app</string>
                 <key>requirement</key>
                 <string>identifier "com.oracle.SQLDeveloper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963</string>
             </dict>

--- a/Scratch-2/Scratch2.munki.recipe
+++ b/Scratch-2/Scratch2.munki.recipe
@@ -50,7 +50,7 @@
 				<key>source_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Install Scratch 2.app/Contents/Resources/Scratch 2</string>
 			   <key>destination_path</key>
-			   <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+			   <string>%RECIPE_CACHE_DIR%/%NAME%/Scratch 2.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -70,7 +70,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>path_list</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Scratch 2.app</string>
 			</dict>
 		</dict>
 	   <dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.