### PR TITLE
Fix No Matched Files error

### DIFF
--- a/Burn/Burn.download.recipe
+++ b/Burn/Burn.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>SOURCEFORGE_FILE_PATTERN</key>
-                <string>burn.*?-64bit.zip</string>
+                <string>burn.*?.zip</string>
                 <key>SOURCEFORGE_PROJECT_ID</key>
                 <integer>169226</integer>
             </dict>


### PR DESCRIPTION
Remove's the 64-bit section as this is no longer required