### PR TITLE
Respondus LockDown Browser Lab Edition:  Resolved issue failing URLTextSearcher

### DIFF
--- a/LockDownBrowser/LockDownBrowserLab.download.recipe
+++ b/LockDownBrowser/LockDownBrowserLab.download.recipe
@@ -57,8 +57,12 @@
                 <string>%SEARCH_URL%</string>
                 <key>re_pattern</key>
                 <string>(\&lt;strong\&gt;Version:\&lt;\/strong\&gt; (?P&lt;version&gt;.*?)\&lt;\/span\&gt;)</string>
+                <key>curl_opts</key>
+                <array>
+                    <string>--header</string>
+                    <string>User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36</string>
+                </array>
             </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/LockDownBrowser/LockDownBrowserLab.download.recipe
+++ b/LockDownBrowser/LockDownBrowserLab.download.recipe
@@ -63,6 +63,7 @@
                     <string>User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36</string>
                 </array>
             </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
Added a user-agent to resolve issue with the server interpreting the curl GET as a Chromebook.

> Installation of the Chromebook App for LockDown Browser is only supported in managed device environments.
> Unfortunately, there isn't a version of LockDown Browser that will run on this device.

I was receiving this on Catalina and Mojave.