### PR TITLE
Update ScratchDesktop.download.recipe

### DIFF
--- a/ScratchDesktop/ScratchDesktop.download.recipe
+++ b/ScratchDesktop/ScratchDesktop.download.recipe
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/Scratch.dmg/Scratch Desktop.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Scratch.dmg/Scratch 3.app</string>
 				<key>requirement</key>
 				<string>identifier "edu.mit.scratch.scratch-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W7AR3WMP87</string>
 			</dict>


### PR DESCRIPTION
The name of the .app changed from Scratch Desktop to Scratch 3, as per @nstrauss's discovery on the MacAdmins Slack. 