### PR TITLE
Update Burn.download.recipe

### DIFF
--- a/Burn/Burn.download.recipe
+++ b/Burn/Burn.download.recipe
@@ -19,7 +19,7 @@
             <key>Arguments</key>
             <dict>
                 <key>SOURCEFORGE_FILE_PATTERN</key>
-                <string>burn.*?.zip</string>
+                <string>burn-[0-9\.]*\.zip</string>
                 <key>SOURCEFORGE_PROJECT_ID</key>
                 <integer>169226</integer>
             </dict>


### PR DESCRIPTION
Fix SOURCEFORGE_FILE_PATTERN to ensure we download the application and not the source code following a change by the developer yesterday.