### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/MinecraftEducation/ClassroomMode.download.recipe
+++ b/MinecraftEducation/ClassroomMode.download.recipe
@@ -43,7 +43,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Classroom Mode for Minecraft.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "com.microsoft.mc-classroommode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>
 		</dict>

--- a/MinecraftEducation/CodeConnectionforMinecraft.download.recipe
+++ b/MinecraftEducation/CodeConnectionforMinecraft.download.recipe
@@ -41,7 +41,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Code Connection for Minecraft.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "com.electron.code-connection-for-minecraft" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.