### PR TITLE
Depreciate Fitbit.munki.recipe

### DIFF
--- a/Fitbit/Fitbit.munki.recipe
+++ b/Fitbit/Fitbit.munki.recipe
@@ -110,11 +110,31 @@ exit 0
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.hansen-m.download.Fitbit</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.
+
+For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569</string>
+            </dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>predicate</key>
+                <string>TRUEPREDICATE</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>FlatPkgUnpacker</string>
@@ -194,18 +214,18 @@ exit 0
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-					<string>%RECIPE_CACHE_DIR%/application_payload</string>
-					<string>%RECIPE_CACHE_DIR%/pkg_unpack</string>
-				</array>
-			</dict>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/application_payload</string>
+                    <string>%RECIPE_CACHE_DIR%/pkg_unpack</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Hi, @aysiu 

This PR depreciates the Munki recipe. The Fitbit macOS application no longer available from the vendor.

For further information please see the following community post: https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569

Thanks!

```
autopkg run -v /Users/paul/Documents/GitHub/aysiu-recipes/Fitbit/Fitbit.munki.recipe 
Processing /Users/paul/Documents/GitHub/aysiu-recipes/Fitbit/Fitbit.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/aysiu-recipes/Fitbit/Fitbit.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
DeprecationWarning: This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569
StopProcessingIf
StopProcessingIf: (TRUEPREDICATE) is True
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.aysiu.munki.Fitbit/receipts/Fitbit.munki-receipt-20221019-122424.plist

The following recipes have deprecation warnings:
    Name          Warning                                                                                                                                                                                                                                                                                                                          
    ----          -------                                                                                                                                                                                                                                                                                                                          
    Fitbit.munki  This recipe has been deprecated. As of October 2022 Fitbit have discontuned their macOS Application. Please remove recipe from your runs.

For further information please see the following community post:https://community.fitbit.com/t5/Windows-10-App/Fitbit-Connect-will-be-discontinued-on-Oct-13-2022/m-p/5193900#M19569  
```