### PR TITLE
Added AppDmgVersioner processor

### DIFF
--- a/MuseScore/MuseScore.munki.recipe
+++ b/MuseScore/MuseScore.munki.recipe
@@ -40,6 +40,15 @@
 	<array>
 		<dict>
             <key>Processor</key>
+            <string>AppDmgVersioner</string>
+            <key>Arguments</key>
+            <dict>
+            	<key>dmg_path</key>
+            	<string>%pathname%</string>
+			</dict>
+		</dict>
+		<dict>
+            <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This is to account for change made in the parent download recipe com.github.jazzace.download.MuseScore which now pulls down version 4 directly from MuseScore. Version 3 was downloaded via a Sparkle feed which populated the version variable previously.