### PR TITLE
Update MinecraftEducation

### DIFF
--- a/MinecraftEducation/MinecraftEducation.download.recipe
+++ b/MinecraftEducation/MinecraftEducation.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/minecraftpe.app</string>
+				<string>%pathname%/minecraft-edu.app</string>
 				<key>requirement</key>
 				<string>identifier "com.microsoft.minecraft-edu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/minecraftpe.app/Contents/Info.plist</string>
+				<string>%pathname%/minecraft-edu.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MinecraftEducation/MinecraftEducation.download.recipe
+++ b/MinecraftEducation/MinecraftEducation.download.recipe
@@ -40,7 +40,7 @@
 				<key>input_path</key>
 				<string>%pathname%/minecraftpe.app</string>
 				<key>requirement</key>
-				<string>identifier "com.microsoft.minecraftpe" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
+				<string>identifier "com.microsoft.minecraft-edu" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/MinecraftEducation/MinecraftEducation.munki.recipe
+++ b/MinecraftEducation/MinecraftEducation.munki.recipe
@@ -25,7 +25,7 @@
 			<key>developer</key>
 			<string>Microsoft Corporation</string>
 			<key>display_name</key>
-			<string>minecraftpe</string>
+			<string>Minecraft Education</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>


### PR DESCRIPTION
Hi, @aysiu 

This PR updates MinecraftEducation recipes to account for the new Bundle ID and app name. 

Output from a successful -v run 
```
autopkg run -v MinecraftEducation.munki.recipe
Looking for com.github.aysiu.download.MinecraftEducation...
Did not find com.github.aysiu.download.MinecraftEducation in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.aysiu.download.MinecraftEducation...
Found com.github.aysiu.download.MinecraftEducation in recipe map
**load_recipe time: 0.005865958999493159
Processing MinecraftEducation.munki.recipe...
WARNING: MinecraftEducation.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aysiu.munki.MinecraftEducation/downloads/minecraftpe.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aysiu.munki.MinecraftEducation/downloads/minecraftpe.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.sXveK6/minecraft-edu.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.sXveK6/minecraft-edu.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.sXveK6/minecraft-edu.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aysiu.munki.MinecraftEducation/downloads/minecraftpe.dmg
Versioner: Found version 1.21.03 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aysiu.munki.MinecraftEducation/downloads/minecraftpe.dmg/minecraft-edu.app/Contents/Info.plist
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/minecraftpe/minecraftpe-1.21.03.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/minecraftpe/minecraftpe-1.21.03.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aysiu.munki.MinecraftEducation/receipts/MinecraftEducation.munki-receipt-20240731-120523.plist

The following new items were imported into Munki:
    Name         Version  Catalogs  Pkginfo Path                                Pkg Repo Path                             Icon Repo Path  
    ----         -------  --------  ------------                                -------------                             --------------  
    minecraftpe  1.21.03  testing   apps/minecraftpe/minecraftpe-1.21.03.plist  apps/minecraftpe/minecraftpe-1.21.03.dmg
```