### PR TITLE
Deprecate Scratch 2 recipe in favor of Scratch Desktop

### DIFF
--- a/Scratch-2/Scratch2.download.recipe
+++ b/Scratch-2/Scratch2.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the ScratchDesktop recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR adds a deprecation warning to the non-functional Scratch 2 recipes.