### PR TITLE
Add code signature verification for Burn recipes

### DIFF
--- a/Burn/Burn.download.recipe
+++ b/Burn/Burn.download.recipe
@@ -37,6 +37,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -44,10 +48,17 @@
                 <true/>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.localized/Burn.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.kiwifruitware.Burn" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5M4D5N9TXW")</string>
+			</dict>
+		</dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification to the Burn recipes.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/elliot/Library/AutoPkg/Cache/com.github.aysiu.download.Burn/Burn/Burn.localized/Burn.app: valid on disk
CodeSignatureVerifier: /Users/elliot/Library/AutoPkg/Cache/com.github.aysiu.download.Burn/Burn/Burn.localized/Burn.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/elliot/Library/AutoPkg/Cache/com.github.aysiu.download.Burn/Burn/Burn.localized/Burn.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```