### PR TITLE
Remove Munki Python dependency in installcheck_script for Google Chrome installcheck

### DIFF
--- a/GoogleChrome/GoogleChromeInstallCheck.munki.recipe
+++ b/GoogleChrome/GoogleChromeInstallCheck.munki.recipe
@@ -66,6 +66,8 @@ fi
                     <key>installcheck_script</key>
                     <string>#!/bin/zsh
 
+# Based loosely on https://github.com/grahamgilbert/chrome_update_notifier/blob/master/payload/Library/Management/chrome_update_notifier.py
+
 autoload is-at-least
 
 desired_version='%version%'


### PR DESCRIPTION
## Issue
The upcoming version of Munki will no longer deliver Python, so `/usr/local/munki/munki-python` won't exist and can't be used in installcheck_scripts.

## Details of PR
Even though we could use https://github.com/macadmins/python/releases instead, it turns out a zsh script is a bit simpler, so this PR rewrites the installcheck_script to use zsh instead.

## Testing Done
Chrome not running:
```
Installed version 140.0.7339.81 is at least 140.0.7339.81, so we can check the running version.
Can't determine running version of Chrome or Chrome isn't running, so considering installed, since the on-disk version is okay.
```
Running version and installed version are both correct:
```
Installed version 140.0.7339.81 is at least 140.0.7339.81, so we can check the running version.
Running version 140.0.7339.81 is at least 140.0.7339.81.
```
Installed version is too low:
```
Installed version 140.0.7339.81 isn't at least 140.0.7339.82.
```
Installed version is correct but the running version is too low:
```
Installed version 140.0.7339.82 is at least 140.0.7339.82, so we can check the running version.
Running version 140.0.7339.81 isn't at least 140.0.7339.82.
```