### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Makeblock/mBlock.download.recipe
+++ b/Makeblock/mBlock.download.recipe
@@ -29,7 +29,7 @@
                         <string>%USER_AGENT%</string>
                 </dict>
                 <key>url</key>
-                <string>http://www.mblock.cc/software-1/mblock/mblock5/#Download</string>
+                <string>https://www.mblock.cc/software-1/mblock/mblock5/#Download</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>

--- a/SQLDeveloper/SQLDeveloper.download.recipe
+++ b/SQLDeveloper/SQLDeveloper.download.recipe
@@ -16,7 +16,7 @@
         <key>AUTHPARAM</key>
         <string>YOURAUTHPARAM</string>
         <key>SEARCH_URL</key>
-        <string>http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html</string>
+        <string>https://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._