### PR TITLE
Update CodexCLI.munki.recipe

### DIFF
--- a/CodexCLI/CodexCLI.munki.recipe
+++ b/CodexCLI/CodexCLI.munki.recipe
@@ -3,13 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest arm64 (Apple Silicon) release of Codex CLI and creates a package that installs the binary to /usr/local/bin.</string>
+	<string>Downloads the latest release of Codex CLI, creates a package that installs the binary to /usr/local/bin and imports it into Munki. Set ARCH to either: arm64 or x86_64</string>
 	<key>Identifier</key>
 	<string>com.github.aysiu.munki.CodexCLI</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>CodexCLI</string>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps</string>
 		<key>MUNKI_CATEGORY</key>
@@ -28,16 +30,43 @@
 			<string>OpenAI</string>
 			<key>display_name</key>
 			<string>Codex CLI</string>
+			<key>minimum_os_version</key>
+			<string>11.0</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
+			<key>version_script</key>
+			<string>#!/bin/sh
+/usr/local/bin/codex --version | /usr/bin/grep -oE '[0-9]+(\.[0-9]+)+'
+</string>
 		</dict>
 	</dict>
 	<key>ParentRecipe</key>
 	<string>com.rderewianko.pkg.CodexCLI</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/usr/local/bin/codex</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
@@ -47,6 +76,17 @@
 				<string>%pkg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
+				</array>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
- Adds dual architecture support from the upstream PKG recipe
- Adds `minimum_os_version`
- Adds `version_script`
- Adds `installs` array